### PR TITLE
Fix files copying

### DIFF
--- a/src/main/scala/com/rocketfuel/build/mool/Bld.scala
+++ b/src/main/scala/com/rocketfuel/build/mool/Bld.scala
@@ -23,7 +23,7 @@ case class Bld(
     srcPaths(model.root, bldPath)
 
   def srcPaths(root: Path, bldPath: MoolPath): Vector[Path] = {
-    val bldDir = bldPath.foldLeft(root)(_.resolve(_))
+    val bldDir = bldPath.foldLeft(root)(_.resolve(_)).getParent
     for {
       src <- srcs.getOrElse(Vector.empty)
     } yield bldDir.resolve(src)


### PR DESCRIPTION
1st commit is just a style
2nd one fixes a problem with file copying where destinations looked like /tmp/mool-conversion/A/src/main/java/com/rocketfuel/lib/Foo/Bar.java with extra Foo in path (assuming java/com/rocketfuel/lib/BLD with java_lib called Foo).